### PR TITLE
Add install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,4 +20,8 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.11",
+    install_requires=[
+        "aiohttp>=3.11",
+        "websockets>=13",
+    ],
 )


### PR DESCRIPTION
The project uses both `aiohttp` and `websockets` so they should be listed as `install_requires` as well.
https://github.com/Taraman17/pyHomee/blob/f989434898e426cf4747e2b60e90cfe0db50adf0/pyHomee/__init__.py#L12-L15