### PR TITLE
fix: connection_listeners typing

### DIFF
--- a/pyHomee/__init__.py
+++ b/pyHomee/__init__.py
@@ -1,7 +1,7 @@
 """Library for interacting with the homee smart home/home automation platform."""
 
 import asyncio
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import Callable, Coroutine
 from datetime import datetime
 import hashlib
 import json
@@ -72,7 +72,9 @@ class Homee:
         self._message_queue = asyncio.Queue()
         self._connected_event = asyncio.Event()
         self._disconnected_event = asyncio.Event()
-        self._connection_listeners = []
+        self._connection_listeners: list[
+            Callable[[bool], Coroutine[Any, Any, None]]
+        ] = []
 
     async def get_access_token(self) -> str:
         """Try asynchronously to get an access token from homee using username and password."""
@@ -301,7 +303,9 @@ class Homee:
 
         self.should_close = True
 
-    async def add_connection_listener(self, listener: Callable[[bool], Awaitable[None]]) -> Callable[[], None]:
+    async def add_connection_listener(
+        self, listener: Callable[[bool], Coroutine[Any, Any, None]]
+    ) -> Callable[[], None]:
         """Add a listener for change in connected state."""
         self._connection_listeners.append(listener)
 


### PR DESCRIPTION
The connection listeners are awaited, so the return type should be `Coroutine[Any, Any, None]` instead of just `None`.

https://github.com/Taraman17/pyHomee/blob/f989434898e426cf4747e2b60e90cfe0db50adf0/pyHomee/__init__.py#L564-L577