### PR TITLE
build: Add License field to project metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setuptools.setup(
     name="pyHomee",
     version=__version__,
+    license="MIT",
     author="Taraman17",
     description="a python library to interact with homee",
     long_description=long_description,


### PR DESCRIPTION
In addition to the license classifier, setuptools allows to specify a license string directly. This will correspond to the `License` field in the project metadata and be displayed alongside the classifier on PyPI.